### PR TITLE
adapting Interval strings to SQL range syntax

### DIFF
--- a/src/model_types.jl
+++ b/src/model_types.jl
@@ -6,7 +6,7 @@ import Base.length
 import Base.==
 import Base.hash
 
-import Dates, Intervals, TimeZones
+import Dates, Intervals
 
 export DbId, SQLType, AbstractModel
 export SQLInput, SQLColumn, SQLColumns, SQLLogicOperator

--- a/src/model_types.jl
+++ b/src/model_types.jl
@@ -641,4 +641,3 @@ mutable struct SQLQuery <: SQLType
 end
 
 string(q::SQLQuery, m::Type{T}) where {T<:AbstractModel} = to_fetch_sql(m, q)
-bb

--- a/src/model_types.jl
+++ b/src/model_types.jl
@@ -640,4 +640,5 @@ mutable struct SQLQuery <: SQLType
     new(columns, where, limit, offset, order, group, having)
 end
 
-string(q::SQLQuery, m::Type{T}) where {T<:AbstractModel} = to_fetch_sql(m, q)b
+string(q::SQLQuery, m::Type{T}) where {T<:AbstractModel} = to_fetch_sql(m, q)
+bb

--- a/src/model_types.jl
+++ b/src/model_types.jl
@@ -6,7 +6,7 @@ import Base.length
 import Base.==
 import Base.hash
 
-import Dates
+import Dates, Intervals, TimeZones
 
 export DbId, SQLType, AbstractModel
 export SQLInput, SQLColumn, SQLColumns, SQLLogicOperator
@@ -122,6 +122,7 @@ SQLInput(i::SQLInput) = i
 SQLInput(s::Symbol) = string(s) |> SQLInput
 SQLInput(r::SQLRaw) = SQLInput(r.value, raw = true)
 SQLInput(n::Nothing) = SQLInput("NULL", escaped = true, raw = true)
+SQLInput(i::Intervals.Interval) = SQLInput(replace(string(i),".."=>","))
 SQLInput(a::Any) = string(a) |> SQLInput
 
 ==(a::SQLInput, b::SQLInput) = a.value == b.value
@@ -639,4 +640,4 @@ mutable struct SQLQuery <: SQLType
     new(columns, where, limit, offset, order, group, having)
 end
 
-string(q::SQLQuery, m::Type{T}) where {T<:AbstractModel} = to_fetch_sql(m, q)
+string(q::SQLQuery, m::Type{T}) where {T<:AbstractModel} = to_fetch_sql(m, q)b


### PR DESCRIPTION
Julia Interval string representation uses ".." to separate bounds, SQL uses ","
This enhancement provides for storing julia intervals with SearchLight.